### PR TITLE
りゅういちくんへ

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -22,7 +22,7 @@ def getTimetable(day):
         return timetable[weekday]
 
 
-bot: disnake.Client = disnake.Client(intents=disnake.Intents.all())
+bot = disnake.Client(intents=disnake.Intents.all())
 
 
 @bot.event

--- a/bot.py
+++ b/bot.py
@@ -1,27 +1,30 @@
 import disnake
-from disnake.ext import commands
-import setting
 import datetime
+import setting
 
 
-timetable = {"日曜日":"**日曜日は休み**",
-             "月曜日":"**月曜日\n\n:one::数学Ⅰ\n:two::国語A\n:three::理科特論\n:four::英語\n:five::数学A\n:six::公民**",
-             "火曜日":"**火曜日\n\n:one::GlobalStudy\n:two::技術\n:three::音楽\n:four::英語\n:five::英語\n:six::保健**",
-             "水曜日": "**水曜日\n\n:one::LHM\n:two::理科Ⅱ\n:three::国語B\n:four::英語\n:five::国語A\n:six::体育**",
-             "木曜日": "**木曜日\n\n:one::国語B\n:two::数学Ⅰ\n:three::歴史\n:four::理科Ⅰ\n:five::美術\n:six::公民**",
-             "金曜日": "**金曜日\n\n:one::数学Ⅰ\n:two::理科Ⅰ\n:three::歴史\n:four::英語\n:five::理科Ⅱ\n:six::体育**",
-             "土曜日": "**土曜日\n\n:one::数学A\n:two::英語\n:three::数学Ⅰ\n:four::道徳**"}
+timetable = {
+    "日曜日": "**日曜日は休み**",
+    "月曜日": "**月曜日\n\n:one::数学Ⅰ\n:two::国語A\n:three::理科特論\n:four::英語\n:five::数学A\n:six::公民**",
+    "火曜日": "**火曜日\n\n:one::GlobalStudy\n:two::技術\n:three::音楽\n:four::英語\n:five::英語\n:six::保健**",
+    "水曜日": "**水曜日\n\n:one::LHM\n:two::理科Ⅱ\n:three::国語B\n:four::英語\n:five::国語A\n:six::体育**",
+    "木曜日": "**木曜日\n\n:one::国語B\n:two::数学Ⅰ\n:three::歴史\n:four::理科Ⅰ\n:five::美術\n:six::公民**",
+    "金曜日": "**金曜日\n\n:one::数学Ⅰ\n:two::理科Ⅰ\n:three::歴史\n:four::英語\n:five::理科Ⅱ\n:six::体育**",
+    "土曜日": "**土曜日\n\n:one::数学A\n:two::英語\n:three::数学Ⅰ\n:four::道徳**"
+}
 
 
-def DayOfWeek(today):
-    weekdays = ["月曜日", "火曜日", "水曜日", "木曜日", "金曜日", "土曜日", "日曜日"]
-    today_weekdays = weekdays[today.weekday()]
+def getTimetable(day) -> str:
+    if isinstance(day, str) and day in timetable:
+        return timetable[day]
+    elif isinstance(day, int):
+        weekday = timetable.keys()[day%7]
+        return timetable[weekday]
 
-    return timetable[today_weekdays]
+
+bot: disnake.Client = disnake.Client(intents=disnake.Intents.all())
 
 
-
-bot = disnake.Client(intents=disnake.Intents.all())
 @bot.event
 async def on_ready():
     print(f'{bot.user.name} has connected to Discord!')
@@ -32,16 +35,15 @@ async def on_message(message):
     if message.author == bot.user:
         return
 
-    print(message.content)
+    today = datetime.date.today()
 
     if  message.content == '時間割':
-        
-        response = DayOfWeek(datetime.date.today())
+        response = getTimetable(today)
 
     elif message.content == '明日の時間割':
-        response = DayOfWeek(datetime.date.today() + datetime.timedelta(days=1))
-    
-    elif 
+        response = getTimetable(today+1)
 
     await message.channel.send(response)
+
+
 bot.run(setting.TOKEN)

--- a/bot.py
+++ b/bot.py
@@ -14,11 +14,11 @@ timetable = {
 }
 
 
-def getTimetable(day) -> str:
+def getTimetable(day):
     if isinstance(day, str) and day in timetable:
         return timetable[day]
     elif isinstance(day, int):
-        weekday = timetable.keys()[day%7]
+        weekday = list(timetable.keys())[day%7]
         return timetable[weekday]
 
 
@@ -35,7 +35,7 @@ async def on_message(message):
     if message.author == bot.user:
         return
 
-    today = datetime.date.today()
+    today = datetime.date.today().day
 
     if  message.content == '時間割':
         response = getTimetable(today)


### PR DESCRIPTION
**DayOfWeek()** -> **getTimetable()** へ名前を変更。
それに加えてgetTimetable()の引数が文字列での曜日（"月曜日"など）の場合と整数の場合でも時間割を返すように変更した。（後々曜日指定で時間割を出力するときに便利）

ーー注釈ーー
**isinstance(object, class)** は第１引数が第２引数に入力した型と一致するかをTrueまたはFalseで返す関数。

```
 elif isinstance(day, int):
        weekday = list(timetable.keys())[day%7]
        return timetable[weekday]
```
上記のコード（20から22行目）は、引数dayがint型（整数）であれば、その値から辞書timetableのキーを選び、辞書の値を出力するコード
21行目が少し複雑だけど、timetable.keys()はtimetableのキーをリストとよく似た形で返す関数で、それをリストへ変換し、そこから引数dayをもとにしてキーの名前をweekdayへ保存している。